### PR TITLE
Update pins

### DIFF
--- a/github_tui.opam
+++ b/github_tui.opam
@@ -36,5 +36,6 @@ build: [
 dev-repo: "git+https://github.com/chshersh/github-tui.git"
 pin-depends: [
   ["minttea.dev" "git+https://github.com/chshersh/minttea"]
+  ["riot.dev" "git+https://github.com/riot-ml/riot"]
   ["shape-the-term.dev" "git+https://github.com/jmcavanillas/shape-the-term"]
 ]

--- a/github_tui.opam.template
+++ b/github_tui.opam.template
@@ -1,4 +1,5 @@
 pin-depends: [
   ["minttea.dev" "git+https://github.com/chshersh/minttea"]
+  ["riot.dev" "git+https://github.com/riot-ml/riot"]
   ["shape-the-term.dev" "git+https://github.com/jmcavanillas/shape-the-term"]
 ]


### PR DESCRIPTION
Currently fails with:

```
[ERROR] The compilation of minttea.dev failed at "dune build -p minttea -j 7 @install".

#=== ERROR while compiling minttea.dev ========================================#
# context     2.1.5 | linux/x86_64 | ocaml.5.2.1 | pinned(git+https://github.com/chshersh/minttea#20286772b1d0399f0af3374da3b6f62b1b00879a)
# path        ~/ocaml/github-tui/_opam/.opam-switch/build/minttea.dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p minttea -j 7 @install
# exit-code   1
# env-file    ~/.opam/log/minttea-41731-113f0f.env
# output-file ~/.opam/log/minttea-41731-113f0f.out
### output ###
# 112 |   let Config.{ render_mode; fps } = config in
# [...]
# Error: Unbound record field "fps"
# (cd _build/default && /home/chshersh/ocaml/github-tui/_opam/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I minttea/.minttea.objs/byte -I /home/chshersh/ocaml/github-tui/_opam/lib/angstrom -I /home/chshersh/ocaml/github-tui/_opam/lib/asn1-combinators -I /home/chshersh/ocaml/github-tui/_opam/lib/base64 -I /home/chshersh/ocaml/github-tui/_opam/lib/bigstringaf -I /home/chshersh/oca[...]
# File "minttea/minttea.ml", line 8, characters 61-72:
# 8 | let config ?(render_mode = `clear) ?(fps = 60) () = Config.{ render_mode; fps }
#                                                                  ^^^^^^^^^^^
# Error: Unbound record field "render_mode"
# (cd _build/default && /home/chshersh/ocaml/github-tui/_opam/bin/ocamlopt.opt -w -40 -g -I minttea/.minttea.objs/byte -I minttea/.minttea.objs/native -I /home/chshersh/ocaml/github-tui/_opam/lib/angstrom -I /home/chshersh/ocaml/github-tui/_opam/lib/asn1-combinators -I /home/chshersh/ocaml/github-tui/_opam/lib/base64 -I /home/chshersh/ocaml/github-tui/_opam/lib/bigstringaf -I /home/chshersh/oca[...]
# File "minttea/renderer.ml", line 112, characters 28-31:
# 112 |   let Config.{ render_mode; fps } = config in
#                                   ^^^
# Error: Unbound record field "fps"
```