### PR TITLE
Rewrite the TUI framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Install libcurl development package
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
@@ -38,6 +41,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Install libcurl development package
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2
         with:
@@ -52,6 +58,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Install libcurl development package
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.2.1
 
     steps:
       - name: Checkout code
@@ -38,10 +38,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use OCaml 5.1.1
+      - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 5.1.1
+          ocaml-compiler: 5.2.1
           dune-cache: true
 
       - name: Lint doc
@@ -53,10 +53,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use OCaml 5.1.1
+      - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 5.1.1
+          ocaml-compiler: 5.2.1
           dune-cache: true
 
       - name: Lint fmt

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.26.2
+version = 0.27.0
 profile = default
 break-cases = fit-or-vertical
 break-infix = wrap-or-vertical

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
    (minttea (>= "0.0.2"))
    shape-the-term
    (terminal_size (>= "0.2.0"))
+   (tty (>= "0.0.2"))
  )
  (tags
   (tui cli git github)))

--- a/dune-project
+++ b/dune-project
@@ -26,6 +26,7 @@
    shape-the-term
    (terminal_size (>= "0.2.0"))
    (tty (>= "0.0.2"))
+   (uutf (>= "1.0.3"))
  )
  (tags
   (tui cli git github)))

--- a/github_tui.opam
+++ b/github_tui.opam
@@ -17,6 +17,7 @@ depends: [
   "minttea" {>= "0.0.2"}
   "shape-the-term"
   "terminal_size" {>= "0.2.0"}
+  "tty" {>= "0.0.2"}
   "odoc" {with-doc}
 ]
 build: [
@@ -35,6 +36,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/chshersh/github-tui.git"
 pin-depends: [
-  ["minttea.dev" "git+https://github.com/chshersh/minttea"]
   ["shape-the-term.dev" "git+https://github.com/jmcavanillas/shape-the-term"]
 ]

--- a/github_tui.opam
+++ b/github_tui.opam
@@ -18,6 +18,7 @@ depends: [
   "shape-the-term"
   "terminal_size" {>= "0.2.0"}
   "tty" {>= "0.0.2"}
+  "uutf" {>= "1.0.3"}
   "odoc" {with-doc}
 ]
 build: [

--- a/github_tui.opam.template
+++ b/github_tui.opam.template
@@ -1,4 +1,3 @@
 pin-depends: [
-  ["minttea.dev" "git+https://github.com/chshersh/minttea"]
   ["shape-the-term.dev" "git+https://github.com/jmcavanillas/shape-the-term"]
 ]

--- a/lib/cli.ml
+++ b/lib/cli.ml
@@ -11,8 +11,15 @@ let path_arg =
     & opt (some string) None
     & info [ "d"; "directory" ] ~docv:"DIRECTORY_PATH" ~doc)
 
-let run repo local_path = Tui.start ~repo ~local_path
-let gh_tui_term = Term.(const run $ repo_arg $ path_arg)
+let log_arg =
+  let doc = "Log debug information to the given file" in
+  Arg.(
+    value
+    & opt (some string) None
+    & info [ "l"; "log-to" ] ~docv:"LOG_PATH" ~doc)
+
+let run repo local_path log_file = Tui.start ~repo ~local_path ~log_file
+let gh_tui_term = Term.(const run $ repo_arg $ path_arg $ log_arg)
 
 let cmd =
   let doc = "TUI of a GitHub repository" in

--- a/lib/fs/fs.mli
+++ b/lib/fs/fs.mli
@@ -1,4 +1,5 @@
-(** File contents as an array of lines, where each line is wrapped into a document (for rendering efficiency) *)
+(** File contents as an array of lines, where each line is wrapped into a
+    document (for rendering efficiency) *)
 type file_contents = {
   lines : Pretty.doc array;
   offset : int;
@@ -46,7 +47,8 @@ val go_down : zipper -> zipper
 (** Move to the previous file within the same directory. Cycles. *)
 val go_up : zipper -> zipper
 
-(** Move to the directory under the current cursor. Doesn't move inside files or empty directories. *)
+(** Move to the directory under the current cursor. Doesn't move inside files or
+    empty directories. *)
 val go_next : zipper -> zipper
 
 (** Move to the parent directory. *)

--- a/lib/log/dune
+++ b/lib/log/dune
@@ -1,0 +1,3 @@
+(library
+ (name log)
+ (libraries unix))

--- a/lib/log/log.ml
+++ b/lib/log/log.ml
@@ -1,0 +1,9 @@
+let log ~path ~tag ~msg =
+  match path with
+  | None -> ()
+  | Some path ->
+      let now = Unix.gettimeofday () in
+      let str = Printf.sprintf "timestamp=%f tag=%s msg=%s\n" now tag msg in
+      Out_channel.(
+        with_open_gen [ Open_creat; Open_append; Open_binary ] 0o644 path
+          (fun channel -> output_string channel str))

--- a/lib/log/log.mli
+++ b/lib/log/log.mli
@@ -1,0 +1,6 @@
+(** Log a single line in the following format to the given file if passed.
+
+    {v
+timestamp=1447865947.56802297 tag=event msg=Retry
+    v} *)
+val log : path:string option -> tag:string -> msg:string -> unit

--- a/lib/pretty/chunk.mli
+++ b/lib/pretty/chunk.mli
@@ -7,5 +7,6 @@ type t = {
 (** Convert a chunk to string, applying formatting *)
 val fmt : t -> string
 
-(** [replicate_chunk n s] creates a chunk without formatting of [n] repeated strings [s]. *)
+(** [replicate_chunk n s] creates a chunk without formatting of [n] repeated
+    strings [s]. *)
 val replicate : int -> string -> t

--- a/lib/pretty/line.mli
+++ b/lib/pretty/line.mli
@@ -1,13 +1,13 @@
 (** A type defining a single line of text with different parts ("chunks") having
-potentially different formatting. *)
+    potentially different formatting. *)
 type t
 
 (** Returns the length of a line as in the number of graphemes (before
-formatting applied). *)
+    formatting applied). *)
 val length : t -> int
 
 (** Smart constructor for a line from a list of chunks to calculate the final
-[length] automatically as well. *)
+    [length] automatically as well. *)
 val of_chunks : Chunk.t list -> t
 
 (** Add a chunk to the beginning of a line. *)

--- a/lib/pretty/pretty.mli
+++ b/lib/pretty/pretty.mli
@@ -9,26 +9,25 @@ val str : string -> doc
 (** Create a single chunk of string with formatting. *)
 val fmt : Style.t -> string -> doc
 
-(** Put all documents in a list horizontally, automatically adding required padding. *)
+(** Put all documents in a list horizontally, automatically adding required
+    padding. *)
 val horizontal : doc list -> doc
 
-(** Put all documents in a list vertically after each other with a line separator. *)
+(** Put all documents in a list vertically after each other with a line
+    separator. *)
 val vertical : doc list -> doc
 
 (** [horizontal_fill filler] fills all the empty horizontal space with the given
-string [filler]. Useful for alignment or separators.
+    string [filler]. Useful for alignment or separators.
 
-{b NOTE:} Only one [horizontal_fill] is allowed per [horizontal] element. The first one
-will be used, the remaining ones will be ignored.
-*)
+    {b NOTE:} Only one [horizontal_fill] is allowed per [horizontal] element.
+    The first one will be used, the remaining ones will be ignored. *)
 val horizontal_fill : string -> doc
 
 (** Render the resulting document.
 
-Parameters:
+    Parameters:
 
-  * [width]: the max allowed width for the document. Passed recursively and
-    currently only used for [horizontal_fill].
-
-*)
+    * [width]: the max allowed width for the document. Passed recursively and
+    currently only used for [horizontal_fill]. *)
 val render : width:int -> doc -> string

--- a/lib/shell/shell.mli
+++ b/lib/shell/shell.mli
@@ -1,11 +1,10 @@
 (** Run a given string as an external process with arguments.
 
-Redirect the called process stdout and stderr to the current process stdout.
+    Redirect the called process stdout and stderr to the current process stdout.
 
-Also print the command with a pretty prompt.
-
-*)
+    Also print the command with a pretty prompt. *)
 val proc : string -> unit
 
-(** Run the given CLI command as external process and collect its stdout to the resulting string. *)
+(** Run the given CLI command as external process and collect its stdout to the
+    resulting string. *)
 val proc_stdout : string -> string

--- a/lib/tui/dune
+++ b/lib/tui/dune
@@ -1,11 +1,11 @@
 (library
  (name tui)
  (libraries
-  minttea
   terminal_size
   ;; Internal dependencies
   extra
   fs
   pretty
   scroll
-  shell))
+  shell
+  tea))

--- a/lib/tui/init.ml
+++ b/lib/tui/init.ml
@@ -1,3 +1,0 @@
-open Minttea
-
-let init _model = Command.(Seq [ Hide_cursor; Enter_alt_screen ])

--- a/lib/tui/tea/dune
+++ b/lib/tui/tea/dune
@@ -1,0 +1,3 @@
+(library
+ (name tea)
+ (libraries tty unix))

--- a/lib/tui/tea/dune
+++ b/lib/tui/tea/dune
@@ -1,3 +1,3 @@
 (library
  (name tea)
- (libraries tty unix))
+ (libraries tty unix uutf log))

--- a/lib/tui/tea/key.ml
+++ b/lib/tui/tea/key.ml
@@ -14,6 +14,17 @@ type t =
   | Enter
   | Key of string
 
+let show_key = function
+  | Up -> "<up>"
+  | Down -> "<down>"
+  | Left -> "<left>"
+  | Right -> "<right>"
+  | Space -> "<space>"
+  | Escape -> "<esc>"
+  | Backspace -> "<backspace>"
+  | Enter -> "<enter>"
+  | Key key -> key
+
 let parse = function
   | " " -> Space
   | "\027" -> Escape
@@ -25,12 +36,23 @@ let parse = function
   | "\n" -> Enter
   | key -> Key key
 
+type read =
+  [ `End
+  | `Malformed of string
+  | `Read of t
+  ]
+
+let show_read = function
+  | `End -> "End"
+  | `Malformed s -> Printf.sprintf "Malformed: %s" s
+  | `Read key -> Printf.sprintf "Key: %s" (show_key key)
+
 let read_key key =
   match key with
   | "\027" -> (
-      match Tty.Stdin.read_utf8 () with
+      match Stdin.read_utf8 () with
       | `Read "[" -> (
-          match Tty.Stdin.read_utf8 () with
+          match Stdin.read_utf8 () with
           | `Read key -> parse ("\027[" ^ key)
           | _ -> parse key)
       | _ -> parse key)
@@ -38,6 +60,6 @@ let read_key key =
   | key -> parse key
 
 let read () =
-  match Tty.Stdin.read_utf8 () with
+  match Stdin.read_utf8 () with
   | `Read key -> `Read (read_key key)
-  | (`Retry | `End | `Malformed _) as other -> other
+  | (`End | `Malformed _) as other -> other

--- a/lib/tui/tea/key.ml
+++ b/lib/tui/tea/key.ml
@@ -1,0 +1,43 @@
+(*    Copied and modified from the original implementation at:
+
+    - https://github.com/leostera/minttea/tree/aa5ef898f6ce4b2a5b359dd6f985cbe2a3583b70
+*)
+
+type t =
+  | Up
+  | Down
+  | Left
+  | Right
+  | Space
+  | Escape
+  | Backspace
+  | Enter
+  | Key of string
+
+let parse = function
+  | " " -> Space
+  | "\027" -> Escape
+  | "\027[A" -> Up
+  | "\027[B" -> Down
+  | "\027[C" -> Right
+  | "\027[D" -> Left
+  | "\127" -> Backspace
+  | "\n" -> Enter
+  | key -> Key key
+
+let read_key key =
+  match key with
+  | "\027" -> (
+      match Tty.Stdin.read_utf8 () with
+      | `Read "[" -> (
+          match Tty.Stdin.read_utf8 () with
+          | `Read key -> parse ("\027[" ^ key)
+          | _ -> parse key)
+      | _ -> parse key)
+  | "\n" -> parse key
+  | key -> parse key
+
+let read () =
+  match Tty.Stdin.read_utf8 () with
+  | `Read key -> `Read (read_key key)
+  | (`Retry | `End | `Malformed _) as other -> other

--- a/lib/tui/tea/key.mli
+++ b/lib/tui/tea/key.mli
@@ -1,0 +1,23 @@
+(** A module to describe and handle possible keyboard events.
+
+    Copied and modified from the original implementation at:
+
+    - https://github.com/leostera/minttea/tree/aa5ef898f6ce4b2a5b359dd6f985cbe2a3583b70
+*)
+
+type t =
+  | Up
+  | Down
+  | Left
+  | Right
+  | Space
+  | Escape
+  | Backspace
+  | Enter
+  | Key of string
+
+(** Parse [t] from the standard sequence of characters. *)
+val parse : string -> t
+
+(** Read a key event from [stdin]. *)
+val read : unit -> [> `Retry | `End | `Malformed of string | `Read of t ]

--- a/lib/tui/tea/key.mli
+++ b/lib/tui/tea/key.mli
@@ -16,8 +16,19 @@ type t =
   | Enter
   | Key of string
 
+(** A function to show [t]. Used for debug purposes. *)
+val show_key : t -> string
+
 (** Parse [t] from the standard sequence of characters. *)
 val parse : string -> t
 
+type read =
+  [ `End
+  | `Malformed of string
+  | `Read of t
+  ]
+
 (** Read a key event from [stdin]. *)
-val read : unit -> [> `Retry | `End | `Malformed of string | `Read of t ]
+val read : unit -> [> read ]
+
+val show_read : read -> string

--- a/lib/tui/tea/stdin.ml
+++ b/lib/tui/tea/stdin.ml
@@ -1,0 +1,31 @@
+(*
+    Copied and modified from the original implementation at:
+
+    - https://github.com/ocaml-tui/tty/blob/d9fad1057a21961eb40564611545a1e0700bc7b3/tty/stdin.ml
+*)
+let stdin_fd = Unix.descr_of_in_channel stdin
+let decoder = Uutf.decoder ~encoding:`UTF_8 `Manual
+
+let try_read () =
+  let bytes = Bytes.create 8 in
+  let ready, _, _ = Unix.select [ stdin_fd ] [] [] (-1.0) in
+  if ready = [] then ()
+  else
+    match Unix.read stdin_fd bytes 0 8 with
+    | exception Unix.(Unix_error ((EINTR | EAGAIN | EWOULDBLOCK), _, _)) -> ()
+    | len -> Uutf.Manual.src decoder bytes 0 len
+
+let uchar_to_str u =
+  let buf = Buffer.create 8 in
+  Uutf.Buffer.add_utf_8 buf u;
+  Buffer.contents buf
+
+let rec read_utf8 () =
+  match Uutf.decode decoder with
+  | `Uchar u -> `Read (uchar_to_str u)
+  | `End -> `End
+  | `Malformed err -> `Malformed err
+  | `Await ->
+      (* We read in a blocking way, so there always should be something in the recursive call. *)
+      try_read ();
+      read_utf8 ()

--- a/lib/tui/tea/stdin.mli
+++ b/lib/tui/tea/stdin.mli
@@ -1,0 +1,10 @@
+(** A module to read key events from keyboards in a blocking way.
+
+    Copied and modified from the original implementation at:
+
+    - https://github.com/ocaml-tui/tty/blob/d9fad1057a21961eb40564611545a1e0700bc7b3/tty/stdin.ml
+*)
+
+(** [read_utf8 ()] will do a blocking read and either return the next valid
+    UTF-8 string available in [stdin] or immediately return. *)
+val read_utf8 : unit -> [> `End | `Malformed of string | `Read of string ]

--- a/lib/tui/tea/tea.ml
+++ b/lib/tui/tea/tea.ml
@@ -1,0 +1,26 @@
+module Key = Key
+
+type 'model t = {
+  init : 'model;
+  view : 'model -> string;
+  update : Key.t -> 'model -> 'model;
+}
+
+let run { init; view; update } =
+  let rec loop model =
+    let output = view model in
+    print_endline output;
+
+    let key = Key.read () in
+    let model =
+      match key with
+      | `Read key -> update key model
+      | _ -> model
+    in
+    loop model
+  in
+
+  let terminal_io = Tty.Stdin.setup () in
+  Fun.protect
+    ~finally:(fun () -> Tty.Stdin.shutdown terminal_io)
+    (fun () -> loop init)

--- a/lib/tui/tea/tea.ml
+++ b/lib/tui/tea/tea.ml
@@ -3,7 +3,7 @@ module Key = Key
 type 'model t = {
   init : 'model;
   view : 'model -> string;
-  update : Key.t -> 'model -> 'model;
+  update : Key.t -> 'model -> [ `Render of 'model | `No_diff | `Quit ];
 }
 
 let setup () =
@@ -33,12 +33,15 @@ let run ?log_file { init; view; update } =
     let key = Key.read () in
     log ~tag:"key" ~msg:(Key.show_read key);
 
-    let model =
+    let updated =
       match key with
       | `Read key -> update key model
-      | _ -> model
+      | _ -> `No_diff
     in
-    loop model
+    match updated with
+    | `No_diff -> loop model
+    | `Render model -> loop model
+    | `Quit -> ()
   in
 
   let terminal_io = setup () in

--- a/lib/tui/tea/tea.ml
+++ b/lib/tui/tea/tea.ml
@@ -22,11 +22,17 @@ let output model_str =
   Tty.Terminal.clear ();
   print_endline model_str
 
-let run { init; view; update } =
+let run ?log_file { init; view; update } =
+  let log = Log.log ~path:log_file in
   let rec loop model =
+    log ~tag:"loop" ~msg:"Loop start";
+
     let model_str = view model in
     output model_str;
+
     let key = Key.read () in
+    log ~tag:"key" ~msg:(Key.show_read key);
+
     let model =
       match key with
       | `Read key -> update key model
@@ -36,6 +42,4 @@ let run { init; view; update } =
   in
 
   let terminal_io = setup () in
-  Fun.protect
-    ~finally:(shutdown terminal_io)
-    (fun () -> loop init)
+  Fun.protect ~finally:(shutdown terminal_io) (fun () -> loop init)

--- a/lib/tui/tea/tea.mli
+++ b/lib/tui/tea/tea.mli
@@ -1,0 +1,13 @@
+(** This module provides a minimalistic TUI framework in The Elm Architecture
+    (TEA) style. *)
+
+module Key = Key
+
+type 'model t = {
+  init : 'model;
+  view : 'model -> string;
+  update : Key.t -> 'model -> 'model;
+}
+
+(** Actually run the TUI application provided the setup *)
+val run : 'model t -> unit

--- a/lib/tui/tea/tea.mli
+++ b/lib/tui/tea/tea.mli
@@ -10,4 +10,4 @@ type 'model t = {
 }
 
 (** Actually run the TUI application provided the setup *)
-val run : 'model t -> unit
+val run : ?log_file:string -> 'model t -> unit

--- a/lib/tui/tea/tea.mli
+++ b/lib/tui/tea/tea.mli
@@ -6,7 +6,7 @@ module Key = Key
 type 'model t = {
   init : 'model;
   view : 'model -> string;
-  update : Key.t -> 'model -> 'model;
+  update : Key.t -> 'model -> [ `Render of 'model | `No_diff | `Quit ];
 }
 
 (** Actually run the TUI application provided the setup *)

--- a/lib/tui/tui.ml
+++ b/lib/tui/tui.ml
@@ -44,10 +44,10 @@ let init ~repo ~local_path : Model.initial_data =
   let { height; width } = get_terminal_dimensions () in
   { repo; root_dir_path; files; width; height }
 
-let start ~repo ~local_path =
+let start ~repo ~local_path ~log_file =
   let initial_data = init ~repo ~local_path in
   let init = Model.initial_model initial_data in
   let app : Model.t Tea.t =
     { init; update = Update.update; view = View.view }
   in
-  Tea.run app
+  Tea.run ?log_file app

--- a/lib/tui/tui.ml
+++ b/lib/tui/tui.ml
@@ -44,10 +44,10 @@ let init ~repo ~local_path : Model.initial_data =
   let { height; width } = get_terminal_dimensions () in
   { repo; root_dir_path; files; width; height }
 
-let app = Minttea.app ~init:Init.init ~update:Update.update ~view:View.view ()
-
 let start ~repo ~local_path =
   let initial_data = init ~repo ~local_path in
-  let initial_model = Model.initial_model initial_data in
-  let config = Minttea.make_config ~fps:1 () in
-  Minttea.start ~config app ~initial_model
+  let init = Model.initial_model initial_data in
+  let app : Model.t Tea.t =
+    { init; update = Update.update; view = View.view }
+  in
+  Tea.run app

--- a/lib/tui/tui.mli
+++ b/lib/tui/tui.mli
@@ -1,1 +1,2 @@
-val start : repo:string -> local_path:string option -> unit
+val start :
+  repo:string -> local_path:string option -> log_file:string option -> unit

--- a/lib/tui/update.ml
+++ b/lib/tui/update.ml
@@ -27,15 +27,15 @@ let move_next (model : Model.t) =
 let update event (model : Model.t) =
   match event with
   (* if we press `q` or the escape key, we exit *)
-  | Key "q" | Escape -> { model with exit = true }
+  | Key "q" | Escape -> `Quit
   (* if we press a digit, we switch to the corresponding tab *)
-  | Key "1" -> { model with current_tab = Model.Code }
-  | Key "2" -> { model with current_tab = Model.Issues }
-  | Key "3" -> { model with current_tab = Model.PullRequests }
+  | Key "1" -> `Render { model with current_tab = Model.Code }
+  | Key "2" -> `Render { model with current_tab = Model.Issues }
+  | Key "3" -> `Render { model with current_tab = Model.PullRequests }
   (* directions/movements *)
-  | Up | Key "k" -> move_up model
-  | Down | Key "j" -> move_down model
-  | Left | Key "h" -> move_back model
-  | Right | Key "l" -> move_next model
+  | Up | Key "k" -> `Render (move_up model)
+  | Down | Key "j" -> `Render (move_down model)
+  | Left | Key "h" -> `Render (move_back model)
+  | Right | Key "l" -> `Render (move_next model)
   (* otherwise, we do nothing *)
-  | _ -> model
+  | _ -> `No_diff

--- a/lib/tui/update.ml
+++ b/lib/tui/update.ml
@@ -1,4 +1,4 @@
-open Minttea
+open Tea.Key
 
 let move_fs move_fn (code_tab : Model.code_tab) =
   let fs = move_fn code_tab.fs in
@@ -27,23 +27,15 @@ let move_next (model : Model.t) =
 let update event (model : Model.t) =
   match event with
   (* if we press `q` or the escape key, we exit *)
-  | Event.KeyDown ((Key "q" | Escape), _modifier) ->
-      ( { model with exit = true },
-        Command.(Seq [ Exit_alt_screen; Show_cursor; Quit ]) )
+  | Key "q" | Escape -> { model with exit = true }
   (* if we press a digit, we switch to the corresponding tab *)
-  | Event.KeyDown (Key "1", _modifier) ->
-      ({ model with current_tab = Model.Code }, Command.Noop)
-  | Event.KeyDown (Key "2", _modifier) ->
-      ({ model with current_tab = Model.Issues }, Command.Noop)
-  | Event.KeyDown (Key "3", _modifier) ->
-      ({ model with current_tab = Model.PullRequests }, Command.Noop)
+  | Key "1" -> { model with current_tab = Model.Code }
+  | Key "2" -> { model with current_tab = Model.Issues }
+  | Key "3" -> { model with current_tab = Model.PullRequests }
   (* directions/movements *)
-  | Event.KeyDown ((Up | Key "k"), _modifier) -> (move_up model, Command.Noop)
-  | Event.KeyDown ((Down | Key "j"), _modifier) ->
-      (move_down model, Command.Noop)
-  | Event.KeyDown ((Left | Key "h"), _modifier) ->
-      (move_back model, Command.Noop)
-  | Event.KeyDown ((Right | Key "l"), _modifier) ->
-      (move_next model, Command.Noop)
+  | Up | Key "k" -> move_up model
+  | Down | Key "j" -> move_down model
+  | Left | Key "h" -> move_back model
+  | Right | Key "l" -> move_next model
   (* otherwise, we do nothing *)
-  | _ -> (model, Command.Noop)
+  | _ -> model

--- a/lib/tui/widget.ml
+++ b/lib/tui/widget.ml
@@ -176,8 +176,8 @@ let children_to_doc ~prev_total ~pos children =
     |> Extra.List.in_between ~sep:mid
     |> (fun lines -> [ top ] @ lines @ [ bot ])
     |> (fun lines ->
-         let pad_before = List.init (max (connect_pos - 1) 0) (fun _ -> "") in
-         pad_before @ lines)
+    let pad_before = List.init (max (connect_pos - 1) 0) (fun _ -> "") in
+    pad_before @ lines)
     |> List.map str
     |> vertical
   in


### PR DESCRIPTION
In this PR,

- Move away from `minttea` to the custom simple TUI framework
- Use blocking read from the keyboard to avoid busy-looping
- Introduce Diff/No_diff to avoid rerendering the same model