### PR TITLE
Use binary icon for binary file types

### DIFF
--- a/lib/fs/fs.ml
+++ b/lib/fs/fs.ml
@@ -1,5 +1,5 @@
 type file_contents =
-  | Binary of { offset : int }
+  | Binary
   | Text of {
       lines : Pretty.doc array;
       offset : int;
@@ -50,7 +50,7 @@ let read_file_raw path = Shell.proc_stdout (bat_cmd ^ path)
 (* Reads file contents using 'bat' to have pretty syntax highlighting *)
 let read_file_contents path =
   let contents = read_file_raw path in
-  if has_binary_warning contents then Binary { offset = 0 }
+  if has_binary_warning contents then Binary
   else
     let lines =
       contents
@@ -102,19 +102,19 @@ let span = 40
 let update_cursor cursor offset =
   match cursor with
   | Text cur -> File_cursor (Text { cur with offset })
-  | Binary _ -> File_cursor (Binary { offset })
+  | Binary -> File_cursor Binary
 
 let offset_from_file_contents = function
   | Text { offset; _ } -> offset
-  | Binary { offset } -> offset
+  | Binary -> 0
 
 let line_len_from_file_contents = function
   | Text { lines; _ } -> Array.length lines
-  | Binary _ -> 1
+  | Binary -> 1
 
 let lines_from_file_contents = function
   | Text { lines; _ } -> lines
-  | Binary _ -> [| Pretty.str binary_file_warning |]
+  | Binary -> [| Pretty.str binary_file_warning |]
 
 let go_down zipper =
   match zipper.current with

--- a/lib/fs/fs.ml
+++ b/lib/fs/fs.ml
@@ -19,8 +19,7 @@ let binary_file_pattern = Str.regexp ".*\\[bat warning\\].*Binary.*content*."
 let binary_file_warning = "This file is binary and cannot be displayed"
 
 let bat_cmd =
-  "bat --style=numbers,changes --color=always --italic-text=always \
-   --paging=never --terminal-width=80 "
+  {|bat --style=numbers,changes --color=always --italic-text=always --paging=never --terminal-width=80 |}
 
 let has_binary_warning contents =
   Str.string_match binary_file_pattern contents 0

--- a/lib/fs/fs.mli
+++ b/lib/fs/fs.mli
@@ -1,18 +1,15 @@
 (** File contents as an array of lines, where each line is wrapped into a
     document (for rendering efficiency) *)
-type file_contents = {
-  lines : Pretty.doc array;
-  offset : int;
-}
-
-(** If bat reports the file as being binary or not *)
-type file_type =
-  | Text
-  | Binary
+type file_contents =
+  | Binary of { offset : int }
+  | Text of {
+      lines : Pretty.doc array;
+      offset : int;
+    }
 
 (** A definition of a file tree. *)
 type tree =
-  | File of string * file_contents Lazy.t * file_type Lazy.t
+  | File of string * file_contents Lazy.t
   | Dir of string * tree array
 
 (** Return the name of a given tree node. *)
@@ -58,3 +55,12 @@ val go_next : zipper -> zipper
 
 (** Move to the parent directory. *)
 val go_back : zipper -> zipper
+
+(** Return line length for arbitrary file *)
+val line_len_from_file_contents : file_contents -> int
+
+(** Return lines for arbitrary file *)
+val lines_from_file_contents : file_contents -> Pretty.doc array
+
+(** Return offset for arbitrary file *)
+val offset_from_file_contents : file_contents -> int

--- a/lib/fs/fs.mli
+++ b/lib/fs/fs.mli
@@ -1,7 +1,7 @@
 (** File contents as an array of lines, where each line is wrapped into a
     document (for rendering efficiency) *)
 type file_contents =
-  | Binary of { offset : int }
+  | Binary
   | Text of {
       lines : Pretty.doc array;
       offset : int;

--- a/lib/fs/fs.mli
+++ b/lib/fs/fs.mli
@@ -5,9 +5,14 @@ type file_contents = {
   offset : int;
 }
 
+(** If bat reports the file as being binary or not *)
+type file_type =
+  | Text
+  | Binary
+
 (** A definition of a file tree. *)
 type tree =
-  | File of string * file_contents lazy_t
+  | File of string * file_contents Lazy.t * file_type Lazy.t
   | Dir of string * tree array
 
 (** Return the name of a given tree node. *)

--- a/lib/tui/tui.ml
+++ b/lib/tui/tui.ml
@@ -21,7 +21,7 @@ let read_root_tree ~root_dir_path =
   let tree = Fs.read_tree root_dir_path in
   let files =
     match tree with
-    | Fs.File (path, _) ->
+    | Fs.File (path, _, _) ->
         Printf.printf "Given path '%s' is not a directory!" path;
         exit 1
     | Fs.Dir (_, files) -> files

--- a/lib/tui/tui.ml
+++ b/lib/tui/tui.ml
@@ -21,7 +21,7 @@ let read_root_tree ~root_dir_path =
   let tree = Fs.read_tree root_dir_path in
   let files =
     match tree with
-    | Fs.File (path, _, _) ->
+    | Fs.File (path, _) ->
         Printf.printf "Given path '%s' is not a directory!" path;
         exit 1
     | Fs.Dir (_, files) -> files

--- a/lib/tui/widget.ml
+++ b/lib/tui/widget.ml
@@ -104,7 +104,7 @@ let fmt_file ~max_name_len (tree : Fs.tree) =
   | File (name, contents) -> (
       match Lazy.force contents with
       | Fs.Text _ -> file_char ^ " " ^ pad name
-      | Fs.Binary _ -> bin_char ^ " " ^ pad name)
+      | Fs.Binary -> bin_char ^ " " ^ pad name)
   | Dir (name, [||]) -> empty_dir_char ^ " " ^ pad name
   | Dir (name, _) -> dir_char ^ " " ^ pad name
 

--- a/lib/tui/widget.ml
+++ b/lib/tui/widget.ml
@@ -58,6 +58,7 @@ let pwd_char = "\u{e5fd}"
 let dir_char = "\u{f4d4}"
 let empty_dir_char = "\u{f413}"
 let file_char = "\u{f4a5}"
+let bin_char = "\u{eae8}"
 
 let parents_path parents =
   List.fold_left (fun acc cur -> Filename.concat acc cur) "" (List.rev parents)
@@ -101,7 +102,8 @@ let max_file_name_len files =
 let fmt_file ~max_name_len (tree : Fs.tree) =
   let pad = Extra.String.fill_right max_name_len in
   match tree with
-  | File (name, _) -> file_char ^ " " ^ pad name
+  | File (name, _, ft) when Lazy.force ft = Binary -> bin_char ^ " " ^ pad name
+  | File (name, _, _) -> file_char ^ " " ^ pad name
   | Dir (name, [||]) -> empty_dir_char ^ " " ^ pad name
   | Dir (name, _) -> dir_char ^ " " ^ pad name
 
@@ -233,7 +235,7 @@ let fs_to_view (fs : Fs.zipper) =
     | File_cursor contents, parent :: _ -> (parent, File_selected contents)
     | Dir_cursor cursor, _ -> (
         match Fs.file_at cursor with
-        | File (_, contents) -> (cursor, File_selected (Lazy.force contents))
+        | File (_, contents, _) -> (cursor, File_selected (Lazy.force contents))
         | Dir (_, children) ->
             ( cursor,
               Dir_selected


### PR DESCRIPTION
First attempt at last part of #8 

Kind of unrelated but in the docs it suggests to use `Lazy.t` instead of `lazy_t` https://ocaml.org/manual/5.3/api/Lazy.html (I don't know if there was a reason to use `lazy_t` - this is the first time I've used `lazy` so could be way off)

The issue that I see with this approach is that now we `bat` the files twice - maybe that's ok? If not let me know if you see a way to set it up so that it's lazily evaluated when either contents or type is needed, but they both get set when that happens. I tried returning a tuple from `read_file_contents` - but I had some trouble getting to work right with `lazy`.

This is what it looks like: 
![image](https://github.com/user-attachments/assets/8f80c337-81e3-4223-bd07-6ec2f5fb1b10)
