### PR TITLE
Move file content stuff into a filec module in Fs

### DIFF
--- a/lib/fs/filec.ml
+++ b/lib/fs/filec.ml
@@ -10,7 +10,9 @@ type t =
    is binary or not. Improve this if it becomes a problem.
 *)
 let binary_file_pattern = Str.regexp ".*\\[bat warning\\].*Binary.*content*."
-let binary_file_warning = "This file is binary and cannot be displayed"
+
+let binary_file_warning =
+  [| Pretty.str "This file is binary and cannot be displayed" |]
 
 let has_binary_warning contents =
   Str.string_match binary_file_pattern contents 0
@@ -21,7 +23,7 @@ let bat_cmd =
 let read_file_raw path = Shell.proc_stdout (bat_cmd ^ path)
 
 (* Reads file contents using 'bat' to have pretty syntax highlighting *)
-let read_file_contents path =
+let read path =
   let contents = read_file_raw path in
   if has_binary_warning contents then Binary
   else
@@ -33,14 +35,15 @@ let read_file_contents path =
     in
     Text { lines; offset = 0 }
 
-let offset_from_file_contents = function
+let offset = function
   | Text { offset; _ } -> offset
   | Binary -> 0
 
-let line_len_from_file_contents = function
-  | Text { lines; _ } -> Array.length lines
-  | Binary -> 1
-
-let lines_from_file_contents = function
+(* Returns the lines of the file contents *)
+let lines = function
   | Text { lines; _ } -> lines
-  | Binary -> [| Pretty.str binary_file_warning |]
+  | Binary -> binary_file_warning
+
+(* Returns the number of lines in the file contents *)
+let length = function
+  | x -> Array.length (lines x)

--- a/lib/fs/filec.ml
+++ b/lib/fs/filec.ml
@@ -1,0 +1,46 @@
+type t =
+  | Binary
+  | Text of {
+      lines : Pretty.doc array;
+      offset : int;
+    }
+
+(* Regex to used to determine if bat outputs a binary file warning. This is a
+   bit of a fragile approach, but there is no robust way to determine if a file
+   is binary or not. Improve this if it becomes a problem.
+*)
+let binary_file_pattern = Str.regexp ".*\\[bat warning\\].*Binary.*content*."
+let binary_file_warning = "This file is binary and cannot be displayed"
+
+let has_binary_warning contents =
+  Str.string_match binary_file_pattern contents 0
+
+let bat_cmd =
+  {|bat --style=numbers,changes --color=always --italic-text=always --paging=never --terminal-width=80 |}
+
+let read_file_raw path = Shell.proc_stdout (bat_cmd ^ path)
+
+(* Reads file contents using 'bat' to have pretty syntax highlighting *)
+let read_file_contents path =
+  let contents = read_file_raw path in
+  if has_binary_warning contents then Binary
+  else
+    let lines =
+      contents
+      |> String.split_on_char '\n'
+      |> List.map Pretty.str
+      |> Array.of_list
+    in
+    Text { lines; offset = 0 }
+
+let offset_from_file_contents = function
+  | Text { offset; _ } -> offset
+  | Binary -> 0
+
+let line_len_from_file_contents = function
+  | Text { lines; _ } -> Array.length lines
+  | Binary -> 1
+
+let lines_from_file_contents = function
+  | Text { lines; _ } -> lines
+  | Binary -> [| Pretty.str binary_file_warning |]

--- a/lib/fs/filec.ml
+++ b/lib/fs/filec.ml
@@ -45,5 +45,4 @@ let lines = function
   | Binary -> binary_file_warning
 
 (* Returns the number of lines in the file contents *)
-let length = function
-  | x -> Array.length (lines x)
+let length filec = filec |> lines |> Array.length

--- a/lib/fs/filec.mli
+++ b/lib/fs/filec.mli
@@ -8,13 +8,13 @@ type t =
     }
 
 (** Reads file contents using 'bat' to have pretty syntax highlighting **)
-val read_file_contents : string -> t
+val read : string -> t
 
 (** Returns offset based on file type of contents **)
-val offset_from_file_contents : t -> int
+val offset : t -> int
 
 (** Returns the len of file contents **)
-val line_len_from_file_contents : t -> int
+val length : t -> int
 
 (** Returns the lines of file contents **)
-val lines_from_file_contents : t -> Pretty.doc array
+val lines : t -> Pretty.doc array

--- a/lib/fs/filec.mli
+++ b/lib/fs/filec.mli
@@ -1,0 +1,20 @@
+(** File contents as an array of lines, where each line is wrapped into a
+    document (for rendering efficiency) *)
+type t =
+  | Binary
+  | Text of {
+      lines : Pretty.doc array;
+      offset : int;
+    }
+
+(** Reads file contents using 'bat' to have pretty syntax highlighting **)
+val read_file_contents : string -> t
+
+(** Returns offset based on file type of contents **)
+val offset_from_file_contents : t -> int
+
+(** Returns the len of file contents **)
+val line_len_from_file_contents : t -> int
+
+(** Returns the lines of file contents **)
+val lines_from_file_contents : t -> Pretty.doc array

--- a/lib/fs/fs.ml
+++ b/lib/fs/fs.ml
@@ -1,29 +1,24 @@
-type file_contents =
-  | Binary
-  | Text of {
-      lines : Pretty.doc array;
-      offset : int;
-    }
+module Filec = Filec
 
 type tree =
-  | File of string * file_contents Lazy.t
+  | File of string * Filec.t Lazy.t
   | Dir of string * tree array Lazy.t
 
-(* Regex to used to determine if bat outputs a binary file warning. This is a
-   bit of a fragile approach, but there is no robust way to determine if a file
-   is binary or not. Improve this if it becomes a problem.
-*)
-let binary_file_pattern = Str.regexp ".*\\[bat warning\\].*Binary.*content*."
-let binary_file_warning = "This file is binary and cannot be displayed"
+type dir_cursor = {
+  pos : int;
+  files : tree array;
+}
 
-let bat_cmd =
-  {|bat --style=numbers,changes --color=always --italic-text=always --paging=never --terminal-width=80 |}
+type cursor =
+  | Dir_cursor of dir_cursor
+  | File_cursor of Filec.t
 
-let has_binary_warning contents =
-  Str.string_match binary_file_pattern contents 0
+let update_cursor cursor offset =
+  match cursor with
+  | Filec.Text cur -> File_cursor (Filec.Text { cur with offset })
+  | Filec.Binary -> File_cursor Filec.Binary
 
 (* Extracts the file name from a tree node *)
-
 let file_name = function
   | File (name, _) -> name
   | Dir (name, _) -> name
@@ -45,21 +40,6 @@ let rec sort_tree = function
       Array.sort order_files children;
       Dir (name, lazy (Array.map sort_tree children))
 
-let read_file_raw path = Shell.proc_stdout (bat_cmd ^ path)
-
-(* Reads file contents using 'bat' to have pretty syntax highlighting *)
-let read_file_contents path =
-  let contents = read_file_raw path in
-  if has_binary_warning contents then Binary
-  else
-    let lines =
-      contents
-      |> String.split_on_char '\n'
-      |> List.map Pretty.str
-      |> Array.of_list
-    in
-    Text { lines; offset = 0 }
-
 (* Recursively reads a directory tree *)
 let rec to_tree path =
   if Sys.is_directory path then
@@ -71,19 +51,9 @@ let rec to_tree path =
     in
     let dirname = Filename.basename path in
     Dir (dirname, children)
-  else File (Filename.basename path, lazy (read_file_contents path))
+  else File (Filename.basename path, lazy (Filec.read_file_contents path))
 
 let read_tree path = path |> to_tree |> sort_tree
-
-type dir_cursor = {
-  pos : int;
-  files : tree array;
-}
-
-type cursor =
-  | Dir_cursor of dir_cursor
-  | File_cursor of file_contents
-
 let file_at cursor = cursor.files.(cursor.pos)
 
 type zipper = {
@@ -100,23 +70,6 @@ let zipper_parents zipper =
 (* TODO: Horrible hardcoding of maximum lines view *)
 let span = 40
 
-let update_cursor cursor offset =
-  match cursor with
-  | Text cur -> File_cursor (Text { cur with offset })
-  | Binary -> File_cursor Binary
-
-let offset_from_file_contents = function
-  | Text { offset; _ } -> offset
-  | Binary -> 0
-
-let line_len_from_file_contents = function
-  | Text { lines; _ } -> Array.length lines
-  | Binary -> 1
-
-let lines_from_file_contents = function
-  | Text { lines; _ } -> lines
-  | Binary -> [| Pretty.str binary_file_warning |]
-
 let go_down zipper =
   match zipper.current with
   | Dir_cursor cursor ->
@@ -125,8 +78,8 @@ let go_down zipper =
       let new_cursor = Dir_cursor { cursor with pos = new_pos } in
       { zipper with current = new_cursor }
   | File_cursor cursor ->
-      let len = line_len_from_file_contents cursor in
-      let new_offset = offset_from_file_contents cursor + 1 in
+      let len = Filec.line_len_from_file_contents cursor in
+      let new_offset = Filec.offset_from_file_contents cursor + 1 in
       if new_offset + span > len then zipper
       else { zipper with current = update_cursor cursor new_offset }
 
@@ -138,7 +91,7 @@ let go_up zipper =
       let new_cursor = Dir_cursor { cursor with pos = new_pos } in
       { zipper with current = new_cursor }
   | File_cursor cursor ->
-      let new_offset = max 0 (offset_from_file_contents cursor - 1) in
+      let new_offset = max 0 (Filec.offset_from_file_contents cursor - 1) in
       { zipper with current = update_cursor cursor new_offset }
 
 let go_next zipper =

--- a/lib/fs/fs.ml
+++ b/lib/fs/fs.ml
@@ -51,7 +51,7 @@ let rec to_tree path =
     in
     let dirname = Filename.basename path in
     Dir (dirname, children)
-  else File (Filename.basename path, lazy (Filec.read_file_contents path))
+  else File (Filename.basename path, lazy (Filec.read path))
 
 let read_tree path = path |> to_tree |> sort_tree
 let file_at cursor = cursor.files.(cursor.pos)
@@ -78,8 +78,8 @@ let go_down zipper =
       let new_cursor = Dir_cursor { cursor with pos = new_pos } in
       { zipper with current = new_cursor }
   | File_cursor cursor ->
-      let len = Filec.line_len_from_file_contents cursor in
-      let new_offset = Filec.offset_from_file_contents cursor + 1 in
+      let len = Filec.length cursor in
+      let new_offset = Filec.offset cursor + 1 in
       if new_offset + span > len then zipper
       else { zipper with current = update_cursor cursor new_offset }
 
@@ -91,7 +91,7 @@ let go_up zipper =
       let new_cursor = Dir_cursor { cursor with pos = new_pos } in
       { zipper with current = new_cursor }
   | File_cursor cursor ->
-      let new_offset = max 0 (Filec.offset_from_file_contents cursor - 1) in
+      let new_offset = max 0 (Filec.offset cursor - 1) in
       { zipper with current = update_cursor cursor new_offset }
 
 let go_next zipper =

--- a/lib/fs/fs.mli
+++ b/lib/fs/fs.mli
@@ -1,4 +1,5 @@
-(** Module for manipulating different file contents (text, binary) to get lines and current offsets. *)
+(** Module for manipulating different file contents (text, binary) to get lines
+    and current offsets. *)
 module Filec = Filec
 
 (** A definition of a file tree. *)

--- a/lib/fs/fs.mli
+++ b/lib/fs/fs.mli
@@ -1,3 +1,4 @@
+(** Module for manipulating different file contents (text, binary) to get lines and current offsets. *)
 module Filec = Filec
 
 (** A definition of a file tree. *)

--- a/lib/fs/fs.mli
+++ b/lib/fs/fs.mli
@@ -1,15 +1,8 @@
-(** File contents as an array of lines, where each line is wrapped into a
-    document (for rendering efficiency) *)
-type file_contents =
-  | Binary
-  | Text of {
-      lines : Pretty.doc array;
-      offset : int;
-    }
+module Filec = Filec
 
 (** A definition of a file tree. *)
 type tree =
-  | File of string * file_contents Lazy.t
+  | File of string * Filec.t Lazy.t
   | Dir of string * tree array Lazy.t
 
 (** Return the name of a given tree node. *)
@@ -26,7 +19,7 @@ type dir_cursor = {
 
 type cursor =
   | Dir_cursor of dir_cursor
-  | File_cursor of file_contents
+  | File_cursor of Filec.t
 
 (** Return the currently selected file in file cursor. *)
 val file_at : dir_cursor -> tree
@@ -55,12 +48,3 @@ val go_next : zipper -> zipper
 
 (** Move to the parent directory. *)
 val go_back : zipper -> zipper
-
-(** Return line length for arbitrary file *)
-val line_len_from_file_contents : file_contents -> int
-
-(** Return lines for arbitrary file *)
-val lines_from_file_contents : file_contents -> Pretty.doc array
-
-(** Return offset for arbitrary file *)
-val offset_from_file_contents : file_contents -> int

--- a/lib/tui/widget.ml
+++ b/lib/tui/widget.ml
@@ -71,10 +71,10 @@ let pwd root_dir_path (fs : Fs.zipper) =
   Pretty.(fmt Style.directory full_path)
 
 let file_contents_to_doc ~(file_contents : Fs.Filec.t) =
-  let lines = Fs.Filec.lines_from_file_contents file_contents in
+  let lines = Fs.Filec.lines file_contents in
   let len_lines = Array.length lines in
   let span = 40 in
-  let offset = Fs.Filec.offset_from_file_contents file_contents in
+  let offset = Fs.Filec.offset file_contents in
 
   let contents_span = Extra.List.of_sub_array ~offset ~len:span lines in
 

--- a/lib/tui/widget.ml
+++ b/lib/tui/widget.ml
@@ -70,11 +70,11 @@ let pwd root_dir_path (fs : Fs.zipper) =
   let full_path = pwd_char ^ " " ^ Filename.concat root_dir_name pwd_path in
   Pretty.(fmt Style.directory full_path)
 
-let file_contents_to_doc ~(file_contents : Fs.file_contents) =
-  let lines = Fs.lines_from_file_contents file_contents in
+let file_contents_to_doc ~(file_contents : Fs.Filec.t) =
+  let lines = Fs.Filec.lines_from_file_contents file_contents in
   let len_lines = Array.length lines in
   let span = 40 in
-  let offset = Fs.offset_from_file_contents file_contents in
+  let offset = Fs.Filec.offset_from_file_contents file_contents in
 
   let contents_span = Extra.List.of_sub_array ~offset ~len:span lines in
 
@@ -103,8 +103,8 @@ let fmt_file ~max_name_len (tree : Fs.tree) =
   match tree with
   | File (name, contents) -> (
       match Lazy.force contents with
-      | Fs.Text _ -> file_char ^ " " ^ pad name
-      | Fs.Binary -> bin_char ^ " " ^ pad name)
+      | Fs.Filec.Text _ -> file_char ^ " " ^ pad name
+      | Fs.Filec.Binary -> bin_char ^ " " ^ pad name)
   | Dir (name, (lazy children)) -> (
       match children with
       | [||] -> empty_dir_char ^ " " ^ pad name
@@ -199,7 +199,7 @@ let is_directory_contents = function
   | _ -> false
 
 type selected_node =
-  | File_selected of Fs.file_contents
+  | File_selected of Fs.Filec.t
   | Dir_selected of {
       prev_total : int;
       pos : int;


### PR DESCRIPTION
An attempt at addressing: #16 

I used the name `Filec` to avoid any conflict with the `File` constructor for the `tree` type in `Fs` here: https://github.com/chshersh/github-tui/blob/main/lib/fs/fs.mli#L12 (eg so that there's no confusion matching on `Fs.File` / `Fs.Dir` vs using `Fs.File.t` and the functions in there)