### PR TITLE
Refactor file type check (lazy and only 1024 bytes)

### DIFF
--- a/lib/fs/filec.ml
+++ b/lib/fs/filec.ml
@@ -43,6 +43,15 @@ let read path =
     in
     Text { lines; offset = 0 }
 
+type file_type =
+  | BinaryFile
+  | TextFile
+
+(* Returns file type based on contents *)
+let type_of_path path = if is_likely_binary path then BinaryFile else TextFile
+
+(* Returns offset based on file type of contents *)
+
 let offset = function
   | Text { offset; _ } -> offset
   | Binary -> 0

--- a/lib/fs/filec.ml
+++ b/lib/fs/filec.ml
@@ -12,9 +12,9 @@ let binary_file_warning =
 
 let open_file_bin num_bytes path =
   let buffer = Bytes.create num_bytes in
-  let ic = open_in_bin path in
-  let n = input ic buffer 0 num_bytes in
-  close_in ic;
+  let n =
+    In_channel.with_open_bin path (fun ic -> input ic buffer 0 num_bytes)
+  in
   Bytes.sub buffer 0 n
 
 let has_zero_bytes buffer =

--- a/lib/fs/filec.mli
+++ b/lib/fs/filec.mli
@@ -1,27 +1,19 @@
 (** File contents as an array of lines, where each line is wrapped into a
     document (for rendering efficiency) *)
-type t =
-  | Binary
-  | Text of {
-      lines : Pretty.Doc.t array;
-      offset : int;
-    }
+type t = {
+  lines : Pretty.Doc.t array;
+  offset : int;
+}
 
 type file_type =
-  | BinaryFile
-  | TextFile
+  | Binary
+  | Text
 
 (** Reads file contents using 'bat' to have pretty syntax highlighting **)
 val read : string -> t
 
-(** Returns offset based on file type of contents **)
-val offset : t -> int
-
 (** Returns the len of file contents **)
 val length : t -> int
-
-(** Returns the lines of file contents **)
-val lines : t -> Pretty.Doc.t array
 
 (** Returns file_type based on the first 1024 bytes of the file **)
 val type_of_path : string -> file_type

--- a/lib/fs/filec.mli
+++ b/lib/fs/filec.mli
@@ -7,6 +7,10 @@ type t =
       offset : int;
     }
 
+type file_type =
+  | BinaryFile
+  | TextFile
+
 (** Reads file contents using 'bat' to have pretty syntax highlighting **)
 val read : string -> t
 
@@ -18,3 +22,6 @@ val length : t -> int
 
 (** Returns the lines of file contents **)
 val lines : t -> Pretty.Doc.t array
+
+(** Returns file_type based on the first 1024 bytes of the file **)
+val type_of_path : string -> file_type

--- a/lib/fs/fs.ml
+++ b/lib/fs/fs.ml
@@ -79,13 +79,10 @@ let move_dir_cursor move cursor =
   { cursor with pos = new_pos }
 
 let move_file_cursor move cursor =
-  match cursor with
-  | Filec.Binary -> cursor
-  | Filec.Text txt_cur ->
-      let len = Filec.length cursor in
-      let new_offset = Filec.offset cursor + move in
-      if new_offset < 0 || new_offset + span > len then cursor
-      else Filec.Text { txt_cur with offset = new_offset }
+  let len = Filec.length cursor in
+  let new_offset = cursor.offset + move in
+  if new_offset < 0 || new_offset + span > len then cursor
+  else { cursor with offset = new_offset }
 
 let go_move move zipper =
   let move_dir = move_dir_cursor move in

--- a/lib/fs/fs.mli
+++ b/lib/fs/fs.mli
@@ -4,7 +4,7 @@ module Filec = Filec
 
 (** A definition of a file tree. *)
 type tree =
-  | File of string * Filec.t Lazy.t
+  | File of string * Filec.t Lazy.t * Filec.file_type Lazy.t
   | Dir of string * tree array Lazy.t
 
 (** Return the name of a given tree node. *)

--- a/lib/tui/tui.ml
+++ b/lib/tui/tui.ml
@@ -29,7 +29,7 @@ let read_root_tree ~root_dir_path =
   let tree = Fs.read_tree root_dir_path in
   let files =
     match tree with
-    | Fs.File (path, _) ->
+    | Fs.File (path, _, _) ->
         Printf.printf "Given path '%s' is not a directory!" path;
         exit 1
     | Fs.Dir (_, files) -> files

--- a/lib/tui/widget/code.ml
+++ b/lib/tui/widget/code.ml
@@ -58,10 +58,10 @@ let max_file_name_len files =
 let fmt_file ~max_name_len (tree : Fs.tree) =
   let pad = Extra.String.fill_right max_name_len in
   match tree with
-  | File (name, contents) -> (
-      match Lazy.force contents with
-      | Fs.Filec.Text _ -> file_char ^ " " ^ pad name
-      | Fs.Filec.Binary -> bin_char ^ " " ^ pad name)
+  | File (name, _, file_type) -> (
+      match Lazy.force file_type with
+      | Fs.Filec.TextFile -> file_char ^ " " ^ pad name
+      | Fs.Filec.BinaryFile -> bin_char ^ " " ^ pad name)
   | Dir (name, (lazy children)) -> (
       match children with
       | [||] -> empty_dir_char ^ " " ^ pad name
@@ -197,7 +197,7 @@ let fs_to_view (fs : Fs.zipper) =
     | File_cursor contents, parent :: _ -> (parent, File_selected contents)
     | Dir_cursor cursor, _ -> (
         match Fs.file_at cursor with
-        | File (_, contents) -> (cursor, File_selected (Lazy.force contents))
+        | File (_, contents, _) -> (cursor, File_selected (Lazy.force contents))
         | Dir (_, children) ->
             ( cursor,
               Dir_selected

--- a/lib/tui/widget/code.ml
+++ b/lib/tui/widget/code.ml
@@ -28,10 +28,10 @@ let pwd root_dir_path (fs : Fs.zipper) =
   Pretty.Doc.(fmt Style.directory full_path)
 
 let file_contents_to_doc ~(file_contents : Fs.Filec.t) =
-  let lines = Fs.Filec.lines file_contents in
+  let lines = file_contents.lines in
   let len_lines = Array.length lines in
   let span = 40 in
-  let offset = Fs.Filec.offset file_contents in
+  let offset = file_contents.offset in
 
   let contents_span = Extra.List.of_sub_array ~offset ~len:span lines in
 
@@ -60,8 +60,8 @@ let fmt_file ~max_name_len (tree : Fs.tree) =
   match tree with
   | File (name, _, file_type) -> (
       match Lazy.force file_type with
-      | Fs.Filec.TextFile -> file_char ^ " " ^ pad name
-      | Fs.Filec.BinaryFile -> bin_char ^ " " ^ pad name)
+      | Fs.Filec.Text -> file_char ^ " " ^ pad name
+      | Fs.Filec.Binary -> bin_char ^ " " ^ pad name)
   | Dir (name, (lazy children)) -> (
       match children with
       | [||] -> empty_dir_char ^ " " ^ pad name


### PR DESCRIPTION
Closes #29 (regression the binary check introduced). 

I wasn't sure what the shape of `Filec.t` should be now - so as a first pass I left it but made the other changes suggested in #29.