### PR TITLE
Add Code of Conduct and Contributing guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Code of Conduct
+
+This code of conduct outlines our expectations for all those who
+participate in the project development.
+
+We invite all those who participate in the development to help us to
+create safe, inclusive and positive experiences.
+
+## Our Standards
+
+The main concern of `github-tui` developers is friendliness and inclusion.
+As such, we are committed to providing a friendly, safe and welcoming environment.
+So, we are using the following standards in our organization.
+
+### Be inclusive.
+
+We welcome and support people of all backgrounds and identities. This includes,
+but is not limited to members of any sexual orientation, gender identity and
+expression, race, ethnicity, culture, national origin, social and economic
+class, educational level, colour, immigration status, sex, age, size, family
+status, political belief, religion, and mental and physical ability.
+
+Discrimination by any of the above will result in immediate ban.
+
+### Be respectful.
+
+We won't all agree all the time but disagreement is no excuse for disrespectful
+behaviour.  We will all experience frustration from time to time, but we cannot
+allow that frustration to become personal attacks. An environment where people
+feel uncomfortable or threatened is not a productive or creative one.
+
+### Choose your words carefully.
+
+Always conduct yourself professionally. Be kind to others. Do not insult or put
+down others.  Harassment and exclusionary behaviour aren't acceptable. This
+includes, but is not limited to:
+
+  * Threats of violence.
+  * Discriminatory language.
+  * Personal insults, especially those using racist or sexist terms.
+  * Advocating for, or encouraging, any of the above behaviours.
+
+### Don't harass.
+
+In general, if someone asks you to stop something, then stop. When we disagree,
+try to understand why. Differences of opinion and disagreements are mostly
+unavoidable. What is important is that we resolve disagreements and differing
+views constructively.
+
+### Make differences into strengths.
+
+Different people have different perspectives on issues, and that can be valuable
+for solving problems or generating new ideas. Being unable to understand why
+someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that we
+all make mistakes, and blaming each other doesn’t get us anywhere.
+
+Instead, focus on resolving issues and learning from mistakes.
+
+##  Reporting Guidelines
+
+If you are subject to or witness unacceptable behaviour, or have any other concerns,
+please notify Dmitrii Kovainikov (the current admin of GitHub TUI) as soon as possible.
+
+You can reach them via the following email:
+
+ * chshersh@gmail.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+This document describes contributing guidelines for the GitHub TUI project.
+
+You're encouraged to read this document before your first contribution.
+Spending your time familiarising yourself with these
+guidelines is much appreciated because following this guide ensures
+the most positive outcome for contributors and maintainers! 💖
+
+## How to contribute
+
+Everyone is welcome to contribute as long as they follow our
+[rules for polite and respectful communication](./CODE_OF_CONDUCT.md)!
+
+And you can contribute to GitHub TUI in multiple ways:
+
+1. Share your success stories or confusion moments when using GitHub TUI under
+   [Discussions](https://github.com/chshersh/github-tui/discussions).
+2. Open [Issues](https://github.com/chshersh/github-tui/issues) with bug
+   reports or feature suggestions.
+3. Open [Pull Requests (PRs)](https://github.com/chshersh/github-tui/pulls)
+   with documentation improvements, changes to the code or even
+   implementation of desired changes!
+
+If you would like to open a PR, **create the issue first** if it
+doesn't exist. Discussing implementation details or various
+architecture decisions avoids spending time inefficiently.
+
+> [!NOTE]
+> You may argue that sometimes it's easier to share your vision with
+> exact code changes via a PR. Still, it's better to start a
+> Discussion or an Issue first by mentioning that you'll open a PR
+> later with your thoughts laid out in code.
+>
+> For fixing typos, opening just a PR is fine. Use your judgement.
+
+If you want to take an existing issue, please, share your intention to
+work on something in the comment section under the corresponding
+issue. This avoids the situation when multiple people are working on
+the same problem concurrently.
+
+## Pull Requests requirements
+
+Generally, the process of submitting, reviewing and accepting PRs
+should be as lightweight as possible if you've discussed the
+implementation beforehand. However, there're still a few requirements:
+
+1. Be polite and respectful in communications. Follow our
+   [Code of Conduct](./CODE_OF_CONDUCT.md).
+2. The code should be formatted with `ocamlformat`
+   using the [project-specific configuration][ocamlformat-config].
+   Your changes will be rejected if they don't follow the formatting
+   requirements.
+3. Add an entry to `CHANGELOG.md` describing your changes in the format similar
+   to other changes.
+
+[ocamlformat-config]: https://github.com/chshersh/github-tui/blob/main/.ocamlformat
+
+That's all so far!
+
+> ![NOTE]
+> PRs are merged to the `main` branch using the
+> "Squash and merge" button. You can produce granular commit history
+> to make the review easier or if it's your preferred workflow. But
+> all commits will be squashed when merged to `main`.
+
+## Write access to the repository
+
+If you want to gain write access to the repository, open a
+[discussion with the Commit Bits category](https://github.com/chshersh/github-tui/discussions/categories/commit-bits)
+and mention your willingness to have it.
+
+I ([@chshersh](https://github.com/chshersh))
+grant write access to everyone who contributed to GitHub TUI.


### PR DESCRIPTION
Adding some guidelines for ensuring we don't stress from working on this project (stressing out about breaking the rules doesn't count).

**TL;DR:** Be respectful, behave like an adult and prefer discussing issues first to avoid conflicts and unexpected ambiguity.

Please, read it and let me know if the wording doesn't make sense or if something is unclear.

cc @heathhenley @thezbm @loadre @qexat since you contributed in the past and may want to contribute in the future

I'll keep this PR open for **1 week** to give you folks some time to review and discuss, and then I'll merge it on February 9th.

<hr>

As for long-term goals, I plan to work on this project today, tomorrow, in one week, in one month and this year. Then we'll see.

Maybe Microsoft will recognise this wholesome effort and pay me huge bucks. But to be realistic, most likely, people will try GitHub TUI and just start constantly complaining a lot about something not working.

My plan is to make the 1.0 release this year (see [milestones](https://github.com/chshersh/github-tui/milestones) for the roadmap).

- The **1.0~alpha** release is just barely useable with minimal features (viewing issues, PRs, reading, replying).
- The **1.0~beta** release is to ensure stability and fix corner cases
- The final **1.0** release is announcing beta, letting people try and fix all bugs that come afterwards

The current stage is **pre-alpha**. I'll continue to exercise my power of BDFL and push to `main` directly until **alpha** is done. Obviously, I'll be reasonable to avoid conflicts with current PRs.

Then, I'll slow down and start working through PRs (if we still have contributors who can review the code).

Happy to discuss further!