### PR TITLE
Refactor unnecessary code in Client.query

### DIFF
--- a/lib/gh/client.ml
+++ b/lib/gh/client.ml
@@ -39,7 +39,6 @@ let query query_body =
             let doc_url =
               Util.member "documentation_url" json |> Util.to_string
             in
-            let code = code in
             Error (Bad_credentials { msg; doc_url; code }))
 
 let parse_response (path : string list) (parse_item : Yojson.Basic.t -> 'a) json


### PR DESCRIPTION
Accidentally left it in when I was experimenting with GitHub API response body. 