### PR TITLE
Check for Nerd Font and switch

### DIFF
--- a/lib/pretty/dune
+++ b/lib/pretty/dune
@@ -3,5 +3,6 @@
  (libraries
   ansifmt
   shell
+  str
   ;; Internal dependencies
   extra))

--- a/lib/pretty/icon.ml
+++ b/lib/pretty/icon.ml
@@ -12,11 +12,12 @@ type t = {
   issue_char : string;
 }
 
+let fc_list_cmd = {| fc-list | grep 'Hack Nerd Font Mono' |}
+
 (** Use fc-list to check if Hack Nerd Font is installed - this might be a little
     brittle, but it's simple - update if it becomes an issue. **)
 let nerd_font_installed () =
-  let cmd = "fc-list | grep 'Hack Nerd Font Mono' > /dev/null 2>&1" in
-  if Sys.command cmd = 0 then true else false
+  fc_list_cmd |> Shell.proc_stdout |> String.trim |> String.length > 0
 
 let icons =
   if nerd_font_installed () then

--- a/lib/pretty/icon.ml
+++ b/lib/pretty/icon.ml
@@ -29,7 +29,7 @@ let uname_result =
 (* Based on the list of possible folders here: https://github.com/adrg/xdg/blob/master/README.md#other-directories*)
 let mac_font_dirs =
   [
-    "~/Library/Fonts";
+    Unix.getenv "HOME" ^ "/Library/Fonts";
     "/Library/Fonts";
     "/System/Library/Fonts";
     "/Network/Library/Fonts";

--- a/lib/pretty/icon.ml
+++ b/lib/pretty/icon.ml
@@ -12,7 +12,7 @@ type t = {
   issue_char : string;
 }
 
-let hack_nerd_font = "Hack Nerd Font Mono"
+let hack_nerd_font = "HackNerdFontMono"
 let fc_list_cmd = Printf.sprintf "fc-list | grep '%s'" hack_nerd_font
 let uname_cmd = {| uname |}
 

--- a/lib/pretty/icon.ml
+++ b/lib/pretty/icon.ml
@@ -1,11 +1,49 @@
-let closed_char = "\u{ebda}"
-let open_char = "\u{ea64}"
-let merged_char = "\u{e725}"
-let arrow_left_char = "\u{f0a8}"
-let pwd_char = "\u{e5fd}"
-let dir_char = "\u{f4d4}"
-let empty_dir_char = "\u{f413}"
-let file_char = "\u{f4a5}"
-let bin_char = "\u{eae8}"
-let warning = "\u{26A0}"
-let issue_char = "\u{f41b}"
+type t = {
+  closed_char : string;
+  open_char : string;
+  merged_char : string;
+  arrow_left_char : string;
+  pwd_char : string;
+  dir_char : string;
+  empty_dir_char : string;
+  file_char : string;
+  bin_char : string;
+  warning : string;
+  issue_char : string;
+}
+
+(** Use fc-list to check if Hack Nerd Font is installed - this might be a little
+    brittle, but it's simple - update if it becomes an issue. **)
+let nerd_font_installed () =
+  let cmd = "fc-list | grep 'Hack Nerd Font Mono' > /dev/null 2>&1" in
+  if Sys.command cmd = 0 then true else false
+
+let icons =
+  if nerd_font_installed () then
+    {
+      closed_char = "\u{ebda}";
+      open_char = "\u{ea64}";
+      merged_char = "\u{e725}";
+      arrow_left_char = "\u{f0a8}";
+      pwd_char = "\u{e5fd}";
+      dir_char = "\u{f4d4}";
+      empty_dir_char = "\u{f413}";
+      file_char = "\u{f4a5}";
+      bin_char = "\u{eae8}";
+      warning = "\u{26A0}";
+      issue_char = "\u{f41b}";
+    }
+  else
+    {
+      closed_char = "x";
+      open_char = "o";
+      merged_char = "m";
+      arrow_left_char = "<-";
+      pwd_char = "*";
+      dir_char = "/";
+      empty_dir_char = "/";
+      file_char = "f";
+      bin_char = "b";
+      warning = "!";
+      issue_char = "i";
+    }

--- a/lib/pretty/icon.mli
+++ b/lib/pretty/icon.mli
@@ -1,0 +1,18 @@
+(** A record representing the icon set **)
+type t = {
+  closed_char : string;
+  open_char : string;
+  merged_char : string;
+  arrow_left_char : string;
+  pwd_char : string;
+  dir_char : string;
+  empty_dir_char : string;
+  file_char : string;
+  bin_char : string;
+  warning : string;
+  issue_char : string;
+}
+
+(** Populated with the current icon set based on if Nerd Font is available or or
+    not**)
+val icons : t

--- a/lib/pretty/pretty.ml
+++ b/lib/pretty/pretty.ml
@@ -1,7 +1,6 @@
 module Doc = Doc
 module Layout = Layout
 module Style = Style
-module Icon = Icon
 
 let icons = Icon.icons
 

--- a/lib/pretty/pretty.ml
+++ b/lib/pretty/pretty.ml
@@ -3,5 +3,7 @@ module Layout = Layout
 module Style = Style
 module Icon = Icon
 
+let icons = Icon.icons
+
 let render ~width ~height doc =
   doc |> Doc.render ~width ~height |> Layout.to_lines |> Extra.String.unlines

--- a/lib/pretty/pretty.mli
+++ b/lib/pretty/pretty.mli
@@ -19,6 +19,10 @@ module Layout = Layout
     - https://www.nerdfonts.com/cheat-sheet *)
 module Icon = Icon
 
+val icons : Icon.t
+
+(** A record representing the icon set **)
+
 (** Render a document into the final string
 
     All notes from {!Doc.render} apply. *)

--- a/lib/pretty/pretty.mli
+++ b/lib/pretty/pretty.mli
@@ -13,13 +13,11 @@ module Doc = Doc
     {!Layout.t} is the output of {!Doc.render} with all the sizes calculated. *)
 module Layout = Layout
 
-(** Icons and symbols used for identifying different parts. Symbols from Hack
-    Nerd Font Mono are used when it's available. Symbols list:
+(** A record representign the Icons and symbols used for identifying different
+    parts. Symbols from Hack Nerd Font Mono are used when it's available.
+    Symbols list:
 
     - https://www.nerdfonts.com/cheat-sheet *)
-module Icon = Icon
-
-(** A record representing the icon set **)
 val icons : Icon.t
 
 (** Render a document into the final string

--- a/lib/pretty/pretty.mli
+++ b/lib/pretty/pretty.mli
@@ -19,9 +19,8 @@ module Layout = Layout
     - https://www.nerdfonts.com/cheat-sheet *)
 module Icon = Icon
 
-val icons : Icon.t
-
 (** A record representing the icon set **)
+val icons : Icon.t
 
 (** Render a document into the final string
 

--- a/lib/tui/render/render.ml
+++ b/lib/tui/render/render.ml
@@ -1,5 +1,6 @@
 module Style = Pretty.Style
 module Layout = Pretty.Layout
+module Icon = Pretty.Icon
 
 type 'a t = {
   item : 'a;
@@ -8,8 +9,8 @@ type 'a t = {
 
 let fmt_issue_state (state : Gh.Issue.state) =
   match state with
-  | Open -> Layout.(fmt Style.issue_open Pretty.Icon.issue_char)
-  | Closed -> Layout.(fmt Style.issue_closed Pretty.Icon.issue_char)
+  | Open -> Layout.(fmt Style.issue_open Icon.icons.issue_char)
+  | Closed -> Layout.(fmt Style.issue_closed Icon.icons.issue_char)
 
 let fmt_title (issue : Gh.Issue.t) =
   let open Layout in

--- a/lib/tui/render/render.ml
+++ b/lib/tui/render/render.ml
@@ -1,6 +1,5 @@
 module Style = Pretty.Style
 module Layout = Pretty.Layout
-module Icon = Pretty.Icon
 
 type 'a t = {
   item : 'a;
@@ -9,8 +8,8 @@ type 'a t = {
 
 let fmt_issue_state (state : Gh.Issue.state) =
   match state with
-  | Open -> Layout.(fmt Style.issue_open Icon.icons.issue_char)
-  | Closed -> Layout.(fmt Style.issue_closed Icon.icons.issue_char)
+  | Open -> Layout.(fmt Style.issue_open Pretty.icons.issue_char)
+  | Closed -> Layout.(fmt Style.issue_closed Pretty.icons.issue_char)
 
 let fmt_title (issue : Gh.Issue.t) =
   let open Layout in

--- a/lib/tui/widget/code.ml
+++ b/lib/tui/widget/code.ml
@@ -15,7 +15,7 @@ let pwd root_dir_path (fs : Fs.zipper) =
   let pwd_path = parents_path parents in
   let root_dir_name = Filename.basename root_dir_path in
   let full_path =
-    Pretty.Icon.icons.pwd_char ^ " " ^ Filename.concat root_dir_name pwd_path
+    Pretty.icons.pwd_char ^ " " ^ Filename.concat root_dir_name pwd_path
   in
   Pretty.Doc.(fmt Style.directory full_path)
 

--- a/lib/tui/widget/code.ml
+++ b/lib/tui/widget/code.ml
@@ -15,7 +15,7 @@ let pwd root_dir_path (fs : Fs.zipper) =
   let pwd_path = parents_path parents in
   let root_dir_name = Filename.basename root_dir_path in
   let full_path =
-    Pretty.Icon.pwd_char ^ " " ^ Filename.concat root_dir_name pwd_path
+    Pretty.Icon.icons.pwd_char ^ " " ^ Filename.concat root_dir_name pwd_path
   in
   Pretty.Doc.(fmt Style.directory full_path)
 
@@ -52,12 +52,12 @@ let fmt_file ~max_name_len (tree : Fs.tree) =
   match tree with
   | File { name; file_type; _ } -> (
       match Lazy.force file_type with
-      | Fs.Filec.Text -> Pretty.Icon.file_char ^ " " ^ pad name
-      | Fs.Filec.Binary -> Pretty.Icon.bin_char ^ " " ^ pad name)
+      | Fs.Filec.Text -> Pretty.icons.file_char ^ " " ^ pad name
+      | Fs.Filec.Binary -> Pretty.icons.bin_char ^ " " ^ pad name)
   | Dir { name; children = (lazy children) } -> (
       match children with
-      | [||] -> Pretty.Icon.empty_dir_char ^ " " ^ pad name
-      | _ -> Pretty.Icon.dir_char ^ " " ^ pad name)
+      | [||] -> Pretty.icons.empty_dir_char ^ " " ^ pad name
+      | _ -> Pretty.icons.dir_char ^ " " ^ pad name)
 
 let current_level_to_doc (cursor : Fs.dir_cursor) ~has_next ~is_file_chosen =
   let open Pretty.Doc in

--- a/lib/tui/widget/common.ml
+++ b/lib/tui/widget/common.ml
@@ -4,7 +4,7 @@ let fmt_error (error : Gh.Client.error) =
   | No_github_token ->
       [
         str
-          (Pretty.Icon.warning
+          (Pretty.icons.warning
          ^ " GITHUB_TOKEN not found. Make sure it's configured in your \
             environment.");
         str "";
@@ -13,7 +13,7 @@ let fmt_error (error : Gh.Client.error) =
       ]
   | Bad_credentials { msg; doc_url; code } ->
       [
-        str (Format.sprintf "%s [%d] %s" Pretty.Icon.warning code msg);
+        str (Format.sprintf "%s [%d] %s" Pretty.icons.warning code msg);
         str "";
         str ("Documentation url: " ^ doc_url);
       ]
@@ -21,7 +21,7 @@ let fmt_error (error : Gh.Client.error) =
       [
         str
           (Format.sprintf "%s GitHub API returned error code: %d"
-             Pretty.Icon.warning code);
+             Pretty.icons.warning code);
         str "";
         str msg;
       ]

--- a/lib/tui/widget/generic.ml
+++ b/lib/tui/widget/generic.ml
@@ -66,7 +66,9 @@ let vlist_border ~scroll_start ~selected items =
         let first_line =
           Doc.(
             horizontal
-              [ fmt_selected_line hd; str " "; str Pretty.Icon.arrow_left_char ])
+              [
+                fmt_selected_line hd; str " "; str Pretty.icons.arrow_left_char;
+              ])
         in
         let other_lines = List.map fmt_selected_line tl in
         first_line :: other_lines

--- a/lib/tui/widget/pr.ml
+++ b/lib/tui/widget/pr.ml
@@ -7,9 +7,9 @@ let section (tab : Model.Pr.t) =
     | None ->
         let fmt_state = function
           | None -> str ""
-          | Some Gh.Pr.Merged -> fmt Style.pr_merged Pretty.Icon.merged_char
-          | Some Gh.Pr.Open -> fmt Style.pr_open Pretty.Icon.open_char
-          | Some Gh.Pr.Closed -> fmt Style.pr_closed Pretty.Icon.closed_char
+          | Some Gh.Pr.Merged -> fmt Style.pr_merged Pretty.icons.merged_char
+          | Some Gh.Pr.Open -> fmt Style.pr_open Pretty.icons.open_char
+          | Some Gh.Pr.Closed -> fmt Style.pr_closed Pretty.icons.closed_char
         in
         let fmt_pr (pr : Gh.Pr.t) =
           Pretty.Doc.(


### PR DESCRIPTION
This is on top of #51, part of #14   - it uses `fc-list` to check if Nerd Font is there, if it is it uses the normal icons, if not, it just uses simple characters (probably needs some work - but it's a start).

Here's what it is looks like with no font installed: 

![image](https://github.com/user-attachments/assets/73f406ed-df33-41a9-93c2-7ead0151dbcb)
![Screenshot 2025-02-11 232410](https://github.com/user-attachments/assets/5ff6b3f3-a96b-49d4-9329-7e6ca5101d1f)
![image](https://github.com/user-attachments/assets/36a191da-af51-41c0-8b91-dceff76aeb8a)

There is still something weird going on with WSL - all my WSL terminals report that I have nerd font installed, but if I use the Windows "Terminal" app, make a new Ubuntu WSL terminal, and try it, `fc-list` says it's installed (it's the same file system) but I unfortunately can't see the fonts. However, in WSL in the vscode terminal (I usually run connected to WSL) it works, so still might be little more to figure out. Worried it might be based on host fonts (?), but in that case both should be working for me so tbd... 

Let me know what you think so far of the approach 