### PR TITLE
GH-55: Provide a better error message in case of failure while cloning the repository

### DIFF
--- a/lib/shell/shell.ml
+++ b/lib/shell/shell.ml
@@ -1,7 +1,15 @@
 let proc cmd =
   Printf.eprintf "🐚  %s\n%!" cmd;
-  let _exit_code = Unix.system cmd in
-  ()
+  match Unix.system cmd with
+  | Unix.WEXITED 0 -> Ok ()
+  | Unix.WEXITED return_code ->
+      Error
+        (Printf.sprintf "command '%s' failed with code %d" (String.escaped cmd)
+           return_code)
+  | Unix.WSIGNALED number | Unix.WSTOPPED number ->
+      Error
+        (Printf.sprintf "command '%s' was stopped by signal (%d)"
+           (String.escaped cmd) number)
 
 let collect_chan (channel : in_channel) : string =
   let rec loop acc =

--- a/lib/shell/shell.mli
+++ b/lib/shell/shell.mli
@@ -3,7 +3,7 @@
     Redirect the called process stdout and stderr to the current process stdout.
 
     Also print the command with a pretty prompt. *)
-val proc : string -> unit
+val proc : string -> (unit, string) result
 
 (** Run the given CLI command as external process and collect its stdout to the
     resulting string. *)

--- a/lib/tui/init/init.ml
+++ b/lib/tui/init/init.ml
@@ -22,7 +22,11 @@ let clone_repo ~owner_repo ~local_path =
         Printf.sprintf "git clone git@github.com:%s/%s.git %s" owner repo
           temp_dir
       in
-      Shell.proc cmd;
+      Shell.proc cmd
+      |> Result.iter_error (fun message ->
+             Printf.eprintf "❌ %s\n" message;
+             exit 1);
+
       temp_dir
 
 let read_root_tree ~root_dir_path =


### PR DESCRIPTION
Fixes #55

Before this commit, the function that handled invoking the cloning command did not perform any error handling.
This PR attempts to fix that ; this means that `Shell.proc` now returns a `result` instead of `unit`, which is a breaking change. As such, the code that depends on this function - such as `clone_repo` in `Tui.Init` was updated to handle the result and exit with a better error message (well, at least one that is more useful).

Things that I am still not convinced about in this fix:
- The return type of `Shell.proc` is `(unit, string) result`. I am not really sure about crafting the error message there.
- `clone_repo` currently exits, but since it is an "internal" function (it is not exposed in the interface of the module), it is probably safer to make it return a `result` as well (as it is fallible) and let a public function exit on failure.